### PR TITLE
Changes to fix connection and table close method

### DIFF
--- a/src/main/java/org/apache/hadoop/hbase/client/HBaseMultiClusterConfigUtil.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HBaseMultiClusterConfigUtil.java
@@ -8,7 +8,6 @@ import java.util.zip.*;
 import com.cloudera.api.ClouderaManagerClientBuilder;
 import com.cloudera.api.DataView;
 import com.cloudera.api.model.*;
-import com.cloudera.api.v1.*;
 import com.cloudera.api.v8.RootResourceV8;
 import com.cloudera.api.v8.ServicesResourceV8;
 import org.apache.cxf.jaxrs.ext.multipart.InputStreamDataSource;

--- a/src/main/java/org/apache/hadoop/hbase/client/HConnectionManagerMultiClusterWrapper.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HConnectionManagerMultiClusterWrapper.java
@@ -20,10 +20,9 @@ public class HConnectionManagerMultiClusterWrapper {
             .getStringCollection(ConfigConst.HBASE_FAILOVER_CLUSTERS_CONFIG);
 
     if (failoverClusters.size() == 0) {
-      LOG.info(" -- Getting a signle cluster connection !!");
+      LOG.info(" -- Getting a single cluster connection !!");
       return HConnectionManager.createConnection(conf);
-    } else {
-
+    } else { 
       Map<String, Configuration> configMap = HBaseMultiClusterConfigUtil
           .splitMultiConfigFile(conf);
 

--- a/src/main/java/org/apache/hadoop/hbase/client/HTableStats.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/HTableStats.java
@@ -1,13 +1,10 @@
 package org.apache.hadoop.hbase.client;
 
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.log4j.Logger;
 
 import java.io.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class HTableStats {

--- a/src/main/java/org/apache/hadoop/hbase/client/SpeculativeMutater.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/SpeculativeMutater.java
@@ -16,9 +16,9 @@ import org.apache.commons.logging.LogFactory;
 public class SpeculativeMutater {
   static final Log LOG = LogFactory.getLog(SpeculativeMutater.class);
 
-  static ExecutorService exe = Executors.newFixedThreadPool(200);
+  ExecutorService exe = Executors.newFixedThreadPool(200);
   
-  public static Boolean mutate(final long waitToSendFailover, 
+  public Boolean mutate(final long waitToSendFailover, 
       final long waitToSendFailoverWithException, 
       final HBaseTableFunction<Void> function, 
       final HTableInterface primaryTable,
@@ -85,7 +85,6 @@ public class SpeculativeMutater {
         exeS.submit(call);
       }
       Boolean result = exeS.take().get();
-
       return result;
     } catch (InterruptedException e) {
       e.printStackTrace();
@@ -95,5 +94,9 @@ public class SpeculativeMutater {
       LOG.error(e);
     }    
     return null;
+  }
+  
+  public void shutDown(){
+	  exe.shutdown();
   }
 }

--- a/src/main/java/org/apache/hadoop/hbase/client/SpeculativeRequester.java
+++ b/src/main/java/org/apache/hadoop/hbase/client/SpeculativeRequester.java
@@ -22,7 +22,7 @@ public class SpeculativeRequester<T extends Object> {
   
   static final Log LOG = LogFactory.getLog(SpeculativeRequester.class);
 
-  static ExecutorService exe = Executors.newFixedThreadPool(200);
+  ExecutorService exe = Executors.newFixedThreadPool(200);
   
   public SpeculativeRequester(long waitTimeBeforeRequestingFailover,
       long waitTimeBeforeAcceptingResults,
@@ -117,6 +117,10 @@ public class SpeculativeRequester<T extends Object> {
     
   }
   
+  public void shutDown() {
+	  exe.shutdown();
+  }
+  
   public static class ResultWrapper<T> {
     public Boolean isPrimary;
     public T t;
@@ -127,5 +131,4 @@ public class SpeculativeRequester<T extends Object> {
     }
   }
   
- 
 }

--- a/src/main/java/org/apache/hadoop/hbase/test/MultiThreadedMultiClusterWithCmApiTest.java
+++ b/src/main/java/org/apache/hadoop/hbase/test/MultiThreadedMultiClusterWithCmApiTest.java
@@ -2,7 +2,6 @@ package org.apache.hadoop.hbase.test;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;


### PR DESCRIPTION
Currently even if the `connection` and `table` `close()` methods are called at the end of a simple code to do a `get`, the Java process stays alive. The reason being that the `executors` created in the MCC code for `connection` and `table` objects are not shutdown. The changes in this PR is to fix this issue.
